### PR TITLE
[fixed] 修复 kube-controller-manager 服务配置缺少内容的 bug

### DIFF
--- a/practice/master-installation.md
+++ b/practice/master-installation.md
@@ -183,6 +183,7 @@ systemctl status kube-apiserver
 文件路径`/usr/lib/systemd/system/kube-controller-manager.service`
 
 ```ini
+[Unit]
 Description=Kubernetes Controller Manager
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 


### PR DESCRIPTION
kube-controller-manager.service 缺少了部分内容