### PR TITLE
Fix the typo

### DIFF
--- a/concepts/service.md
+++ b/concepts/service.md
@@ -143,7 +143,7 @@ spec:
 实现基于客户端 IP 的会话亲和性，可以将 `service.spec.sessionAffinity` 的值设置为 `"ClientIP"` （默认值为 `"None"`）。
 
 和 userspace 代理类似，网络返回的结果是，任何到达 `Service` 的 IP:Port 的请求，都会被代理到一个合适的 backend，不需要客户端知道关于 Kubernetes、`Service`、或 `Pod` 的任何信息。
-这应该比 userspace 代理更快、更可靠。然而，不像 userspace 代理，如果初始选择的 `Pod` 没有响应，iptables 代理能够自动地重试另一个 `Pod`，所以它需要依赖 [readiness probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#defining-readiness-probes)。
+这应该比 userspace 代理更快、更可靠。然而，不像 userspace 代理，如果初始选择的 `Pod` 没有响应，iptables 代理不能自动地重试另一个 `Pod`，所以它需要依赖 [readiness probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#defining-readiness-probes)。
 
 ![iptables代理模式下Service概览图](../images/services-iptables-overview.jpg)
 


### PR DESCRIPTION
3.3.4 Service小节，iptables 代理模式小段中有如下这段话：
然而，不像 userspace 代理，如果初始选择的 Pod 没有响应，iptables 代理**能够**自动地重试另一个 Pod，所以它需要依赖 readiness probes。

根据k8s官网文档，https://kubernetes.io/docs/concepts/services-networking/service/#proxy-mode-iptables， 原文如下
However, unlike the userspace proxier, the iptables proxier **cannot** automatically retry another Pod if the one it initially selects does not respond, so it depends on having working readiness probes.