### PR TITLE
fix practice/traefix-ingress-installation.md change name: traefik.yam…

### DIFF
--- a/practice/traefik-ingress-installation.md
+++ b/practice/traefik-ingress-installation.md
@@ -47,7 +47,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ```
 
-**创建名为`traefik-ingress`的ingress**，文件名traefik.yaml
+**创建名为`traefik-ingress`的ingress**，文件名ingress.yaml
 
 ```yaml
 apiVersion: extensions/v1beta1
@@ -75,7 +75,7 @@ spec:
 
 这其中的`backend`中要配置default namespace中启动的service名字，如果你没有配置namespace名字，默认使用default namespace，如果你在其他namespace中创建服务想要暴露到kubernetes集群外部，可以创建新的ingress.yaml文件，同时在文件中指定该`namespace`，其他配置与上面的文件格式相同。。`path`就是URL地址后的路径，如traefik.frontend.io/path，service将会接受path这个路径，host最好使用service-name.filed1.filed2.domain-name这种类似主机名称的命名方式，方便区分服务。
 
-根据你自己环境中部署的service的名字和端口自行修改，有新service增加时，修改该文件后可以使用`kubectl replace -f traefik.yaml`来更新。
+根据你自己环境中部署的service的名字和端口自行修改，有新service增加时，修改该文件后可以使用`kubectl replace -f ingress.yaml`来更新。
 
 我们现在集群中已经有两个service了，一个是nginx，另一个是官方的`guestbook`例子。
 


### PR DESCRIPTION
…l to ingress.yaml

超哥, 我要提 PR...
一定要让我提成功...

https://github.com/rootsongjc/kubernetes-handbook/blob/master/practice/traefik-ingress-installation.md  中 2处文件名更改..

第1处:
```
创建名为traefik-ingress的ingress，文件名traefik.yaml
```
更新为 
```
创建名为traefik-ingress的ingress，文件名ingress.yaml
```
第2处:
```
修改该文件后可以使用kubectl replace -f traefik.yaml来更新。
```
更新为
```
修改该文件后可以使用kubectl replace -f ingress.yaml来更新。
```
