### PR TITLE
更新过时描述

### DIFF
--- a/concepts/serviceaccount.md
+++ b/concepts/serviceaccount.md
@@ -10,7 +10,7 @@ Service account为Pod中的进程提供身份信息。
 
 ## 使用默认的 Service Account 访问 API server
 
-当您创建 pod 的时候，如果您没有指定一个 service account，系统会自动得在与该pod 相同的 namespace 下为其指派一个`default` service account。如果您获取刚创建的 pod 的原始 json 或 yaml 信息（例如使用`kubectl get pods/podename -o yaml`命令），您将看到`spec.serviceAccountName`字段已经被设置为 [automatically set](https://kubernetes.io/docs/user-guide/working-with-resources/#resources-are-automatically-modified) 。
+当您创建 pod 的时候，如果您没有指定一个 service account，系统会自动得在与该pod 相同的 namespace 下为其指派一个`default` service account。如果您获取刚创建的 pod 的原始 json 或 yaml 信息（例如使用`kubectl get pods/podename -o yaml`命令），您将看到`spec.serviceAccountName`字段已经被设置为 `default`。
 
 您可以在 pod 中使用自动挂载的 service account 凭证来访问 API，如 [Accessing the Cluster](https://kubernetes.io/docs/user-guide/accessing-the-cluster/#accessing-the-api-from-a-pod) 中所描述。
 


### PR DESCRIPTION
1. https://kubernetes.io/docs/user-guide/working-with-resources/#resources-are-automatically-modified 锚点不可用
2. kube 1.10 实测结果为 default