### PR TITLE
fix rolebonding description

### DIFF
--- a/practice/create-tls-and-secret-key.md
+++ b/practice/create-tls-and-secret-key.md
@@ -290,7 +290,7 @@ admin.csr  admin-csr.json  admin-key.pem  admin.pem
 ```
 
 + CN 指定该证书的 User 为 `system:kube-proxy`；
-+ `kube-apiserver` 预定义的 RoleBinding `cluster-admin` 将User `system:kube-proxy` 与 Role `system:node-proxier` 绑定，该 Role 授予了调用 `kube-apiserver` Proxy 相关 API 的权限；
++ `kube-apiserver` 预定义的 RoleBinding `system:node-proxier` 将User `system:kube-proxy` 与 Role `system:node-proxier` 绑定，该 Role 授予了调用 `kube-apiserver` Proxy 相关 API 的权限；
 
 生成 kube-proxy 客户端证书和私钥
 


### PR DESCRIPTION
生成kube-proxy证书时user kube-proxy预定义的rolebinding 应该为system:node-proxy

