### PR TITLE
修复typos及PodCondition的type字段增加新值

### DIFF
--- a/concepts/pod-lifecycle.md
+++ b/concepts/pod-lifecycle.md
@@ -2,7 +2,7 @@
 
 ## Pod phase
 
-Pod 的 `status` 在信息保存在 PodStatus 中定义，其中有一个 `phase` 字段。
+Pod 的 `status` 字段是一个 PodStatus 对象，PodStatus中有一个 `phase` 字段。
 
 Pod 的相位（phase）是 Pod 在其生命周期中的简单宏观概述。该阶段并不是对容器或 Pod 的综合汇总，也不是为了做为综合状态机。
 
@@ -22,7 +22,7 @@ Pod 相位的数量和含义是严格指定的。除了本文档中列举的状�
 
 ## Pod 状态
 
-Pod 有一个 PodStatus 对象，其中包含一个 PodCondition 数组。 PodCondition 数组的每个元素都有一个 `type` 字段和一个 `status` 字段。`type` 字段是字符串，可能的值有 PodScheduled、Ready、Initialized 和 Unschedulable。`status` 字段是一个字符串，可能的值有 True、False 和 Unknown。
+Pod 有一个 PodStatus 对象，其中包含一个 PodCondition 数组。 PodCondition 数组的每个元素都有一个 `type` 字段和一个 `status` 字段。`type` 字段是字符串，可能的值有 PodScheduled、Ready、Initialized、Unschedulable和ContainersReady。`status` 字段是一个字符串，可能的值有 True、False 和 Unknown。
 
 ## 容器探针
 

--- a/concepts/pod.md
+++ b/concepts/pod.md
@@ -102,7 +102,7 @@ Pod 原语有利于：
    2. 向Pod中的进程发送TERM信号；
 5. 跟第三步同时，该Pod将从该service的端点列表中删除，不再是replication controller的一部分。关闭的慢的pod将继续处理load balancer转发的流量；
 6. 过了宽限期后，将向Pod中依然运行的进程发送SIGKILL信号而杀掉进程。
-7. Kublete会在API server中完成Pod的的删除，通过将优雅周期设置为0（立即删除）。Pod在API中消失，并且在客户端也不可见。
+7. Kubelet会在API server中完成Pod的的删除，通过将优雅周期设置为0（立即删除）。Pod在API中消失，并且在客户端也不可见。
 
 删除宽限期默认是30秒。 `kubectl delete`命令支持 `—grace-period=<seconds>` 选项，允许用户设置自己的宽限期。如果设置为0将强制删除pod。在kubectl>=1.5版本的命令中，你必须同时使用 `--force` 和 `--grace-period=0` 来强制删除pod。
 在 yaml 文件中可以通过 `{{ .spec.spec.terminationGracePeriodSeconds }}` 来修改此值。


### PR DESCRIPTION
pod.md中kubelet的一个拼写错误。
pod-lifestype.md中修改了下描述。并且根据最新官方文档，PodCondition
的type字段可选的值还有ContainersReady.