### PR TITLE
配置calicoctl环境变量

### DIFF
--- a/concepts/calico.md
+++ b/concepts/calico.md
@@ -42,6 +42,10 @@ wget  https://github.com/projectcalico/calicoctl/releases/download/v2.0.0/calico
 
 mv calicoctl /usr/loca/bin && chmod +x /usr/local/bin/calicoctl
 
+export CALICO_DATASTORE_TYPE=kubernetes
+
+export CALICO_KUBECONFIG=~/.kube/config 
+
 calicoctl get ippool
 
 calicoctl get node


### PR DESCRIPTION
更新calico文档, calicoctl使用前应配置kubeconfig及datastore类型