### PR TITLE
Kubernetes Changelog

### DIFF
--- a/appendix/kubernetes-1.18-changelog.md
+++ b/appendix/kubernetes-1.18-changelog.md
@@ -1,0 +1,6 @@
+# Kubernetes 1.18 更新日志
+
+## 参考
+
+* [Kubernetes 1.18: Fit & Finish](https://kubernetes.io/blog/2020/03/25/kubernetes-1-18-release-announcement/)
+

--- a/appendix/kubernetes-1.19-changelog.md
+++ b/appendix/kubernetes-1.19-changelog.md
@@ -1,0 +1,6 @@
+# Kubernetes 1.19 更新日志
+
+## 参考
+
+* [Kubernetes 1.19: Accentuate the Paw-sitive](https://kubernetes.io/blog/2020/08/26/kubernetes-release-1.19-accentuate-the-paw-sitive/)
+

--- a/appendix/kubernetes-changelog.md
+++ b/appendix/kubernetes-changelog.md
@@ -17,5 +17,7 @@
 - 2019 年 6 月 20 日，[Kubernetes 1.15 发布](kubernetes-1.15-changelog.md)
 - 2019 年 9 月 19 日，[Kubernetes 1.16 发布](kubernetes-1.16-changelog.md)
 - 2019 年 12 月 10 日，[Kubernetes 1.17 发布](kubernetes-1.17-changelog.md)
+- 2020 年 3 月 25 日，[Kubernetes 1.18 发布](kubernetes-1.18-changelog.md)
+- 2020 年 8 月 26 日，[Kubernetes 1.19 发布](kubernetes-1.19-changelog.md)
 
 注：以上时间皆为北京时间。


### PR DESCRIPTION
仅添加 1.18 和 1.19 版本引用，没有对更新内容进行归纳和翻译