### PR TITLE
update:  concepts/pod-hook.md 内容

### DIFF
--- a/concepts/pod-hook.md
+++ b/concepts/pod-hook.md
@@ -27,7 +27,9 @@ spec:
           command: ["/usr/sbin/nginx","-s","quit"]
 ```
 
-在容器创建之后，容器的 Entrypoint 执行之前，这时候 Pod 已经被调度到某台 node 上，被某个 kubelet 管理了，这时候 kubelet 会调用 postStart 操作，该操作跟容器的启动命令是在同步执行的，也就是说在 postStart 操作执行完成之前，kubelet 会锁住容器，不让应用程序的进程启动，只有在 postStart 操作完成之后容器的状态才会被设置成为 RUNNING。
+postStart 在容器创建之后（但并不能保证钩子会在容器 ENTRYPOINT 之前）执行，这时候 Pod 已经被调度到某台 node 上，被某个 kubelet 管理了，这时候 kubelet 会调用 postStart 操作，该操作跟容器的启动命令是在同步执行的，也就是说在 postStart 操作执行完成之前，kubelet 会锁住容器，不让应用程序的进程启动，只有在 postStart 操作完成之后容器的状态才会被设置成为 RUNNING。
+
+PreStop 在容器终止之前被同步阻塞调用，常用于在容器结束前优雅的释放资源。
 
 如果 postStart 或者 preStop hook 失败，将会终止容器。
 


### PR DESCRIPTION
desc: postStart 的执行并不一定是在 ENTRYPOINT 之前被执行的.

![PostStart error description](https://cdn.jsdelivr.net/gh/MinsonLee/minsonlee.github.io/images/pig/pod-hook-error.png)


参考：https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks

![PostStart description](https://cdn.jsdelivr.net/gh/MinsonLee/minsonlee.github.io/images/pig/pod-hook-PostStart.jpg)
